### PR TITLE
Update the extraction of the languages from the subtask name

### DIFF
--- a/tower_eval/tasks/generate.py
+++ b/tower_eval/tasks/generate.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from jsonargparse import CLI
 from loguru import logger
 from tower_eval.models import available_models
-from tower_eval.utils import make_dir_if_not_exists, parse_yaml_config, save_to_json
+from tower_eval.utils import make_dir_if_not_exists, parse_yaml_config, save_to_json, get_langs
 
 
 def parse_gen_eval_config(config_path: str) -> dict:
@@ -77,9 +77,10 @@ def generate(i: int, config_path: str, config_type: str) -> None:
                 f"Running inference for task: <yellow> {task_name} </yellow>, subtask: <green> {subtask} </green> with model: <red> {model_type}/{model_name} </red> saving to: <red> {output_dir} </red>"
             )
             make_dir_if_not_exists(output_file)
-            # seq2seq models and external vendors require language pair information
-            if model_type == "seq2seq" or model_type == "externalvendor":
-                src_lang, tgt_lang = subtask.split(".")[-1].split("-")
+            if task_name in ["mt", "ape"]:
+                lp = subtask.split(".")[-1]
+                src_lang, tgt_lang = get_langs(lp)
+
                 model.source_language = src_lang
                 model.target_language = tgt_lang
             model.generation_with_resume(input_file=input_file, output_file=output_file)

--- a/tower_eval/utils.py
+++ b/tower_eval/utils.py
@@ -221,7 +221,7 @@ def read_lines(path: PathInput, unescape_newline: bool = False) -> List[str]:
         unescape_newline: Whether to unescape newlines.
     Returns:
         The lines in the file."""
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         lines = [l[:-1] for l in f.readlines()]
     if unescape_newline:
         lines = [l.replace("\\n", "\n") for l in lines]
@@ -385,3 +385,13 @@ def tokenize_text(references, tokenizer):
     for reference in tqdm.tqdm(references):
         tokenized_prompts.append(tokenizer.encode(reference))
     return tokenized_prompts
+
+def get_langs(lp):
+    # TODO: This has to be updated to account for more languages
+    valid_langs = ["de", "en-us", "en-gb", "en-uk", "en", "es-latam","es", "fr", "it", "ko", "nl", "pl", "pt-br", "pt", "ru", "zh-CN", "zh"]
+    lang_pattern = "|".join(valid_langs)
+    lp_pattern = rf'^({lang_pattern})-({lang_pattern})$'
+    match = re.match(lp_pattern, lp)
+    src_lang = match.group(1)
+    trg_lang = match.group(2)
+    return src_lang, trg_lang


### PR DESCRIPTION
This MR updates the way we get the language pairs from the subtask name. Instead of relying only on the hyphens, it uses a list of valid language names. Given than we use hyphens both for separating the source and target language (eg. `en-de`) and for the language variants (eg. `pt-br`), and the fact that we can have the languages with variants in either side, this solution seems to be the most reasonable approach.