### PR TITLE
Add the support of gemini-1.5 models to vertexAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,11 @@ In your config file you need to define the following parameteres:
   - `retry_max_attempts`: **[OpenAI and VertexAI only]** The maximum number of retries in case there is no response from OpenAI's generation endpoint.
   - `retry_max_interval`: **[OpenAI and VertexAI only]** The maximum time to wait before re-sending the request in case there is no response from OpenAI's generation endpoint.
   - `retry_min_interval`: **[OpenAI and VertexAI only]** The minimum time to wait before re-sending the request in case there is no response from OpenAI's generation endpoint.
+  - `system_prompt`: This argument is not available for all the models. The ones that support `system_prompt` are:
+    - OpenAI `gpt-4o`
+    - Gemini-1.0 (only `gemini-1.0-pro-002`)
+    - Gemini-1.5 (only `gemini-1.5-flash-001` and `gemini-1.5-pro-001`),
+    - Anthropic: all models
   - `project`: **[`gemini-1.5` models only]**. For detailed information on how to set this variable properly in your config file, please refer to the [Gemini-1.5 documentation](https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-1.5-pro-001).
   - `location`: **[`gemini-1.5` models only]**. For detailed information on how to set this variable properly in your config file, please refer to the [Gemini-1.5 documentation](https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-1.5-pro-001).
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,20 @@ An example config can be found in `configs/examples/gen_eval.yaml`.
 
 <a name="ModelsSection"></a>
 ### Model Arguments
-Currently, tower-eval supports OpenAI models and those supported by ``vllm``.
+Currently, tower-eval supports the models released by `Anthorpic`, `Cohere`, `OpenAI`, the family of models available in `VertexAI` by `Google`, and those supported by ``vllm``.
+The supported models of `vertex-ai` are the followings:
+  - `palm`:
+    - `text-bison`
+    - `text-unicorn`
+    - `text-bison-32k`
+    - `chat-bison`
+  - `gemini` (aka `gemini-1.0`):
+    - `gemini-pro`
+    - `gemini-1.0-pro-002`
+  - `gemini-1.5`:
+    -  `gemini-1.5-flash-001`
+    -  `gemini-1.5-pro-001`
+ 
 
 In your config file you need to define the following parameteres:
 - `name`: This field is primarily used for defining the output folder, and doesn't impact the underlying model used for inference.
@@ -285,6 +298,8 @@ In your config file you need to define the following parameteres:
   - `retry_max_attempts`: **[OpenAI and VertexAI only]** The maximum number of retries in case there is no response from OpenAI's generation endpoint.
   - `retry_max_interval`: **[OpenAI and VertexAI only]** The maximum time to wait before re-sending the request in case there is no response from OpenAI's generation endpoint.
   - `retry_min_interval`: **[OpenAI and VertexAI only]** The minimum time to wait before re-sending the request in case there is no response from OpenAI's generation endpoint.
+  - `project`: **[`gemini-1.5` models only]**. For detailed information on how to set this variable properly in your config file, please refer to the [Gemini-1.5 documentation](https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-1.5-pro-001).
+  - `location`: **[`gemini-1.5` models only]**. For detailed information on how to set this variable properly in your config file, please refer to the [Gemini-1.5 documentation](https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-1.5-pro-001).
 
 For the updated information on the supported models by VertexAI please check the [Model Information page](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models?_ga=2.42102502.-292947728.1686331955) on Google Cloud.
 

--- a/tower_eval/models/vertexAI/__init__.py
+++ b/tower_eval/models/vertexAI/__init__.py
@@ -4,5 +4,8 @@ API_TYPE = {
     "text-bison-32k": "palm",
     "chat-bison": "palm",
     "chat-bison-32k": "palm",
-    "gemini-pro": "gemini"
+    "gemini-pro": "gemini",
+    "gemini-1.0-pro-002": "gemini", # Information available in: https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-pro?project=unbabel-translate-neural
+    "gemini-1.5-flash-001": "gemini-1.5", # Information available in: https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-1.5-flash-001?project=unbabel-translate-neural
+    "gemini-1.5-pro-001": "gemini-1.5", # Information available in: https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-1.5-pro-001?project=unbabel-translate-neural
     }

--- a/tower_eval/models/vertexAI/generator.py
+++ b/tower_eval/models/vertexAI/generator.py
@@ -2,6 +2,11 @@
 import vertexai
 from vertexai.language_models import TextGenerationModel
 from vertexai.preview.generative_models import GenerativeModel
+
+import base64
+
+import vertexai.preview.generative_models as generative_models
+
 from tower_eval.models.exceptions import GenerationException
 from tower_eval.models.inference_handler import Generator
 from tower_eval.utils import generate_with_retries
@@ -48,7 +53,25 @@ class VertexAI(Generator):
         # Gimini and PaLM models need to be called through different model APIs with some small differences.
         # But, to avoid having two different inference endpoint in Tower-Eval we decided to handle both of them here.
         self.model_type = API_TYPE.get(model)
-        if self.model_type == "gemini":
+        if self.model_type == "gemini-1.5":
+            try:
+                project=kwargs["project"]
+                location=kwargs["location"]
+            except:
+                logger.error(f"<red>For Gemeni-1.5 models you need to provide \"project\" and \"location\" in your config file.</red>")
+            vertexai.init(project=project, location=location)
+            from vertexai.generative_models import GenerativeModel
+            self.model = GenerativeModel(model)
+            self.inference_function = self.model.generate_content
+            self.model_args = {
+                "generation_config": {
+                    "max_output_tokens": max_tokens,
+                    "temperature": temperature,
+                    "top_p": top_p,
+                },
+            }
+        elif self.model_type == "gemini":
+            from vertexai.preview.generative_models import GenerativeModel
             self.model = GenerativeModel(model)
             self.inference_function = self.model.generate_content
             self.model_args = {
@@ -83,7 +106,7 @@ class VertexAI(Generator):
             str: Returns the response used.
         """
         try:
-            if self.model_type == "gemini":
+            if self.model_type in ["gemini", "gemini-1.5"]:
                 prompt = {"contents": input_line}
             elif self.model_type == "palm":
                 prompt = {"prompt": input_line}

--- a/tower_eval/models/vertexAI/generator.py
+++ b/tower_eval/models/vertexAI/generator.py
@@ -73,12 +73,7 @@ class VertexAI(Generator):
             }
         elif self.model_type == "gemini":
             from vertexai.preview.generative_models import GenerativeModel
-            if model == "gemini-1.0-pro-002":
-                logger.info(f"Using the following system prompt: {system_prompt}")
-                self.model = GenerativeModel(model, system_instruction=system_prompt)
-            else:
-                logger.info(f"Model \"{model}\" doesn't support system prompt. So, running the inference with user prompt only.")
-                self.model = GenerativeModel(model)
+            self.model = GenerativeModel(model, system_instruction=system_prompt)
             self.inference_function = self.model.generate_content
             self.model_args = {
                 "generation_config": {


### PR DESCRIPTION
This PR adds the support of gemini-1.5 models (`gemini-1.5-flash-001` and `gemini-1.5-pro-001`) to vertexAI.
The README file is also updated with some information on the supported models of VertexAI and the additional variables required for the gemini-1.5 models for the generation step.