### PR TITLE
Update the metrics with language in their arguments

### DIFF
--- a/tower_eval/metrics/errant/metric.py
+++ b/tower_eval/metrics/errant/metric.py
@@ -17,15 +17,15 @@ class ERRANT(Metric):
         self,
         hypothesis_path,
         gold_data_path,
-        references,
-        language: str,
         tokenize_source: bool = False,
         tokenize_hypothesis: bool = False,
         **kwargs
     ) -> dict:
-        hypothesis_m2 = self.preprocess(hypothesis_path, gold_data_path, language)
+        language = kwargs["lp"]["src_lang"]
+        references = kwargs["references_m2"]
+        hypothesis_m2 = self.preprocess(hypothesis_path, gold_data_path, language, tokenize_source, tokenize_hypothesis)
         result = self.evaluate(
-            hypothesis_m2, references, language, tokenize_source, tokenize_hypothesis
+            hypothesis_m2, references
         )
         result.print_result(self.metric_name())
         return result.format_result(self.metric_name())

--- a/tower_eval/tasks/generate.py
+++ b/tower_eval/tasks/generate.py
@@ -79,12 +79,11 @@ def generate(i: int, config_path: str, config_type: str, available_models: dict=
                 f"Running inference for task: <yellow> {task_name} </yellow>, subtask: <green> {subtask} </green> with model: <red> {model_type}/{model_name} </red> saving to: <red> {output_dir} </red>"
             )
 
-            if task_name in ["mt", "ape"]:
-                lp = subtask.split(".")[-1]
-                src_lang, tgt_lang = get_langs(lp)
+            lp = subtask.split(".")[-1]
+            src_lang, tgt_lang = get_langs(lp)
 
-                model.source_language = src_lang
-                model.target_language = tgt_lang
+            model.source_language = src_lang
+            model.target_language = tgt_lang
             model.generation_with_resume(
                 input_file=input_file,
                 output_file=output_file,

--- a/tower_eval/utils.py
+++ b/tower_eval/utils.py
@@ -338,10 +338,9 @@ def get_eval_args_given_task(
     )
     gold_data_path = data_dir / task_name / subtask / "test.jsonl"
     # add language argument to eval_args as it is needed in some metrics
-    language = subtask.split(".")[1]
-    if "-" in language:
-        _, language = get_langs(language)
-    eval_args["language"] = language
+    lp = subtask.split(".")[1]
+    src_lang, trg_lang = get_langs(lp)
+    eval_args["lp"] = {"src_lang": src_lang, "trg_lang": trg_lang}
 
     return hypothesis_path, gold_data_path, eval_args
 
@@ -433,9 +432,17 @@ def get_langs(lp):
     lang_pattern = "|".join(valid_langs)
     lp_pattern = rf"^({lang_pattern})-({lang_pattern})$"
     match = re.match(lp_pattern, lp)
-    src_lang = match.group(1)
-    trg_lang = match.group(2)
-    return src_lang, trg_lang
+    if match:
+        # We have a language pair, so both src_lang and trg_lang will be extracted from lp
+        src_lang = match.group(1)
+        trg_lang = match.group(2)
+        return src_lang, trg_lang
+    elif lp in valid_langs:
+        # the task is monolingual, hence we only have one language. So, we set the src_lang only. trg_lang will be set to None
+        src_lang = lp
+        trg_lang = None
+        return src_lang, trg_lang
+    return None, None
 
 
 def add_average_generation_time(


### PR DESCRIPTION
This MR updates the metrics that in their `run` methods have `language` in the list of the arguments. This includes `Errant` and `F1_Sequence`.
It also updates the `get_langs` method to always return `src_lang` and `trg_lang`variables. Depending on the subtask name, they both might have valid values (usually the case for the bilingual tasks like MT, APE, etc), or try_lang might be None (usually the case for the monolingual tasks like NER, GEC, etc), or both might be None (doesn't happen usually).